### PR TITLE
updated file filter to not include color highlighter theme copies

### DIFF
--- a/schemr.py
+++ b/schemr.py
@@ -79,7 +79,7 @@ class Schemr():
 					all_scheme_paths.append(filepath)
 
 		# Filter out SublimeLinter-generated schemes
-		regex = re.compile('\(SL\)', re.IGNORECASE)
+		regex = re.compile('\(SL\)|Color Highlighter', re.IGNORECASE)
 		all_scheme_paths = [scheme for scheme in all_scheme_paths if not regex.search(scheme)]
 
 		# Given the paths of all the color schemes, add in the information for


### PR DESCRIPTION
With SublimeLinter and Color Highlighter active at the same time we have 3 copies of the same scheme in different places. Schemr works as expected only when changing the original scheme in sublime user preference file. Without filtering out the Color Highlighter versions ST3 will continously freeze while in an "update loop" between SublimeLinter and Color Highlighter both of which are trying to force their copy of the theme to be the currently active one.
