### PR TITLE
Fix find_scheme() always returning False and fix Unicode error

### DIFF
--- a/schemr.py
+++ b/schemr.py
@@ -199,8 +199,8 @@ class Schemr():
 		return scheme_name
 
 	def find_scheme(self, scheme_path):
-		scheme_path = self.filter_scheme_name(scheme_path) + '.tmTheme'
-		matching_paths = [path for name, path, favorited in self.load_schemes() if path == scheme_path]
+		scheme_name = self.filter_scheme_name(scheme_path)
+		matching_paths = [path for name, path, favorited in self.load_schemes() if name == scheme_name]
 		if len(matching_paths) is not 0:
 			return matching_paths[0]
 		else:


### PR DESCRIPTION
I think I introduced a bug last night in PR #20.  My change to `find_scheme()` tries to compare scheme names with scheme paths, and it always returns `False` because it can never find any matches.  This causes **Add current scheme to favorites** to silently fail.

Also included in this PR is a minor tweak to the "★" literal that fixes an error on Windows ST2.
