### PR TITLE
fix: don't stop loading schemes if one has a problem

### DIFF
--- a/schemr.py
+++ b/schemr.py
@@ -147,7 +147,11 @@ class Schemr():
 	# first for ST3 or fallback to the absolute path for ST2.
 	def parse_scheme(self, scheme_path):
 		if int(sublime.version()) >= 3000:
-			xml = sublime.load_resource(scheme_path)
+			try:
+				xml = sublime.load_resource(scheme_path)
+			except:
+				print('Error loading ' + scheme_path)
+				return (0, 0, 0)
 			try:
 				plist = parser.parse_string(xml)
 			except (parser.PropertyListParseError):


### PR DESCRIPTION
Another ST3 plugin installed a bad scheme (UnicodeDecodeError exception thrown when trying to load 'PowerShell/ISE Nostalgia.tmTheme').
Schemr was not working anymore ("List all schemes" was not doing anything anymore). This fix makes it continue to load other schemes when one is not able to, and log the one not loaded.